### PR TITLE
Add exclusions for vscode and sublime project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ jspm_packages
 npm-debug.log
 dist
 .idea
+.vscode
+*.sublime*
 coverage
 
 # OS generated Files #


### PR DESCRIPTION
To keep vscode and sublime project files locally.